### PR TITLE
Various reviewer changes to fusion double

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -2700,8 +2700,9 @@ REFERENCES:
 .. [GJ2007] \A. Glen, J. Justin, Episturmian words: a survey, Preprint,
             2007, :arxiv:`0801.1655`.
 
-.. [Goff1999] Christopher Goff, Isomorphic fusion algebras of twisted quantum doubles 
-            of finite groups. PhD Thesis, University of California, Santa Cruz. 1999.
+.. [Goff1999] Christopher Goff. *Isomorphic fusion algebras of twisted quantum
+              doubles of finite groups*. PhD Thesis,
+              University of California, Santa Cruz. 1999.
 
 .. [GJ2016] Muddappa Seetharama Gowda and Juyoung Jeong.
             Spectral cones in Euclidean Jordan algebras.
@@ -4432,10 +4433,9 @@ REFERENCES:
 .. [Mat2002] Jiří Matousek, "Lectures on Discrete Geometry", Springer,
              2002
 
-.. [Mas1995] Mason, Geoffrey The quantum double of a finite group and its role 
-            in conformal field theory. Groups '93 Galway/St. Andrews, Vol. 2, 
-            405–417, London Math. Soc. Lecture Note Ser., 212, 
-            Cambridge, 1995.
+.. [Mas1995] Mason, Geoffrey. *The quantum double of a finite group and its role
+             in conformal field theory*. Groups '93 Galway/St. Andrews, Vol. 2,
+             405-417, London Math. Soc. Lecture Note Ser., 212, Cambridge, 1995.
 
 .. [Ma2009] Sarah Mason, An Explicit Construction of Type A Demazure
             Atoms, Journal of Algebraic Combinatorics, Vol. 29,

--- a/src/sage/algebras/fusion_rings/fusion_double.py
+++ b/src/sage/algebras/fusion_rings/fusion_double.py
@@ -1,13 +1,18 @@
 """
 The Fusion Ring of the Drinfeld Double of a Finite Group
 """
+
 # ****************************************************************************
 #  Copyright (C) 2023 Wenqi Li
 #                     Daniel Bump <bump at match.stanford.edu>
 #
-#  Distributed under the terms of the GNU General Public License (GPL)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.combinat.free_module import CombinatorialFreeModule
 from sage.rings.integer_ring import ZZ
@@ -21,16 +26,19 @@ from sage.matrix.constructor import matrix
 
 class FusionDouble(CombinatorialFreeModule):
     r"""
-    This constructs the Fusion Ring of the modular tensor category of modules over the Drinfeld
-    Double of a finite group. Usage is similar to :class:`FusionRing`::.
-    Since many of the methods are similar, we assume the reader is familiar with that
-    class.
+    The fusion ring corresponding to the Drinfeld double of a finite group.
+
+    This is the fusion ring of the modular tensor category of modules
+    over the Drinfeld double of a finite group. Usage is similar
+    to :class:`FusionRing`; we refer the reader to that class for more
+    information.
 
     INPUT:
 
     - ``G`` -- a finite group
-    - ``prefix`` (optional: defaults to 's') a prefix for the names of simple objects.
-    - ``inject_varables`` (optional): set TRUE to create variables for the simple objects.
+    - ``prefix`` -- (default: ``'s'``) a prefix for the names of simple objects
+    - ``inject_varables`` -- (optional) set to ``True`` to create variables
+      for the simple objects
 
     REFERENCES:
 
@@ -44,7 +52,8 @@ class FusionDouble(CombinatorialFreeModule):
         sage: G = DihedralGroup(5)
         sage: H = FusionDouble(G, inject_variables=True)
         sage: H.basis()
-        Finite family {0: s0, 1: s1, 2: s2, 3: s3, 4: s4, 5: s5, 6: s6, 7: s7, 8: s8, 9: s9, 10: s10, 11: s11, 12: s12, 13: s13, 14: s14, 15: s15}
+        Finite family {0: s0, 1: s1, 2: s2, 3: s3, 4: s4, 5: s5, 6: s6, 7: s7, 8: s8,
+                       9: s9, 10: s10, 11: s11, 12: s12, 13: s13, 14: s14, 15: s15}
         sage: for x in H.basis():
         ....:     print ("%s : %s"%(x,x^2))
         ....:
@@ -73,89 +82,127 @@ class FusionDouble(CombinatorialFreeModule):
         sage: s8.ribbon()
         zeta5^3
 
-    If the Fusion Double is multiplicity-free, meaning that the fusion coefficients
-    `N_k^{ij}` are bounded by `1`, then the F-matrix may be computed, just as
-    for :class:`FusionRing`. There is a caveat here, since even if the fusion
-    rules are multiplicity-free, if there are many simple objects, the computation
-    may be too large to be practical. At least, this code can compute the F-matrix
-    for the Fusion Double of the symmetric group `S_3`, duplicating the result
-    of [CHW2015]_ .
+    If the fusion double is multiplicity-free, meaning that the fusion
+    coefficients `N_k^{ij}` are bounded by `1`, then the F-matrix may be
+    computed, just as for :class:`FusionRing`. There is a caveat here, since
+    even if the fusion rules are multiplicity-free, if there are many simple
+    objects, the computation may be too large to be practical. At least,
+    this code can compute the F-matrix for the Fusion Double of the
+    symmetric group `S_3`, duplicating the result of [CHW2015]_.
 
-    EXAMPLES::
+    ::
 
         sage: G1 = SymmetricGroup(3)
-        sage: H1 = FusionDouble(G1,prefix="u",inject_variables=True)
+        sage: H1 = FusionDouble(G1, prefix="u", inject_variables=True)
         sage: F = H1.get_fmatrix()
 
-    The above commands create the F-matrix factory. You can compute the F-matrices
-    with the command ::
+    The above commands create the F-matrix. You can compute all of the
+    F-matrices with the command::
 
         sage: H1.find_orthogonal_solution()  # not tested (10-15 minutes)
 
-    Individual F-matrices may be computed thus ::
+    Individual F-matrices may be computed thus::
 
-        sage: F.fmatrix(u3,u3,u3,u4) # not tested
+        sage: F.fmatrix(u3, u3, u3, u4)  # not tested
 
-    see :class:`FMatrix` for more information.
+    See :class:`FMatrix` for more information.
 
-    Unfortunately beyond `S_3` the number of simple objects is larger.
-    Although the :class:`FusionDouble` class and its methods work well
-    for groups of moderate size, the FMatrix may not be available.
-    For the dihedral group of order 8, there are already 22
+    Unfortunately beyond `S_3` the number of simple objects is seemingly
+    impractical. Although the :class:`FusionDouble` class and its methods
+    work well for groups of moderate size, the :class:`FMatrix` may not be
+    computable. For the dihedral group of order 8, there are already 22
     simple objects, and the F-matrix seems out of reach.
 
-    It is an open problem to classify the finite groups whose fusion doubles are
-    multiplicity-free. Abelian groups, dihedral groups, dicyclic groups, and all
-    groups of order 16 are multiplicity-free.  On the other hand, for groups of order 32,
-    some are multiplicity-free and others are not.
+    It is an open problem to classify the finite groups whose fusion doubles
+    are multiplicity-free. Abelian groups, dihedral groups, dicyclic groups,
+    and all groups of order 16 are multiplicity-free.  On the other hand, for
+    groups of order 32, some are multiplicity-free and others are not.
 
-    Some groups, as currently implemented in Sage, may be missing methods such as
-    centralizers which are needed by this code. To circumvent this, you may
-    try to implement them as GAP Permutation groups. Thus ::
+    Some groups, as currently implemented in Sage, may be missing methods such
+    as centralizers which are needed by this code. To circumvent this, you may
+    try to implement them as GAP permutation groups. Thus::
 
-        sage: G1 = GL(2,3)
+        sage: G1 = GL(2, 2)
+        sage: H1 = FusionDouble(G1, prefix="b", inject_variables=True)
+        Traceback (most recent call last):
+        ...
+        AttributeError: 'LinearMatrixGroup_gap_with_category' object has no attribute 'centralizer'
         sage: G2 = G1.as_permutation_group()
-        sage: H2 = FusionDouble(G2,prefix="b",inject_variables=True)
-        sage: b13^2         # long time (43s)
-        b0 + b1 + b5 + b6 + b13 + b26 + b30 + b31 + b32 + b33 + b38 + b39
-        sage: b13.ribbon()
+        sage: H2 = FusionDouble(G2, prefix="b", inject_variables=True)
+        sage: b7^2
+        b0 + b1 + b7
+        sage: b7.ribbon()
         zeta3
 
-    In this example, implementing the simple group of order 168 as
+    In this example, implementing the nonabelian group of order 6 as
     the matrix group ``G1`` will not work with the ``FusionDouble``, so we
-    recreate it as the permutation group ``G2``. Although the test of
-    squaring `b2` takes a long time, the fusion coefficients are cached
-    and this FusionRing is not too slow to work with. (Of course the
-    F-matrix factory is not available for this group.)
+    recreate it as the permutation group ``G2``.
+
+    If we instead used `\GL(2, 3)`, this group has 48 elements. In this case,
+    the first computation of squaring ``b2`` takes a long time. However, the
+    fusion coefficients are cached and this fusion ring is not too slow to work
+    with. (Of course the F-matrix is not available for this group.) ::
+
+        sage: G = GL(2, 3).as_permutation_group()
+        sage: F = FusionDouble(G, prefix="b")
+        sage: b13 = F.basis()[13]
+        sage: b13^2  # long time
+        b0 + b1 + b5 + b6 + b13 + b26 + b30 + b31 + b32 + b33 + b38 + b39
     """
-    def __init__(self, G, prefix="s",inject_variables=False):
+    @staticmethod
+    def __classcall_private__(cls, G, prefix="s", inject_variables=False):
+        """
+        Normalize input to ensure a unique representation.
+
+        EXAMPLES::
+
+            sage: H1 = FusionDouble(DihedralGroup(6), inject_variables=True)
+            sage: H2 = FusionDouble(DihedralGroup(6), prefix='s')
+            sage: H1 is H2
+            True
+        """
+        F = super().__classcall__(cls, G=G, prefix=prefix)
+        if inject_variables:
+            F.inject_variables()
+        return F
+
+    def __init__(self, G, prefix="s"):
         """
         EXAMPLES::
 
-            sage: H = FusionDouble(DihedralGroup(7))
+            sage: H = FusionDouble(DihedralGroup(6))
             sage: TestSuite(H).run()
+            sage: H = FusionDouble(DihedralGroup(7))
+            sage: TestSuite(H).run()  # long time
+
+            sage: F = FusionDouble(CyclicPermutationGroup(2))
+            sage: [F._repr_term(t) for t in F._names]
+            ['s0', 's1', 's2', 's3']
+            sage: F = FusionDouble(CyclicPermutationGroup(2))
+            sage: [F._latex_term(t) for t in F._names]
+            ['s_{0}', 's_{1}', 's_{2}', 's_{3}']
+
+            sage: FusionDouble(SymmetricGroup(4)).get_order()
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         """
         self._G = G
-        self._prefix = prefix
         self._names = {}
         self._elt = {}
         self._chi = {}
-        count = 0
+        count = ZZ.zero()
         for g in G.conjugacy_classes_representatives():
             for chi in G.centralizer(g).irreducible_characters():
-                self._names[count] = "%s%s"%(prefix, count)
+                self._names[count] = "%s%s" % (prefix, count)
                 self._elt[count] = g
                 self._chi[count] = chi
-                count += 1
-        self._rank = count
+                count += ZZ.one()
         self._cyclotomic_order = G.exponent()
         self._basecoer = None
         self._fusion_labels = None
         self._field = None
         cat = AlgebrasWithBasis(ZZ)
-        CombinatorialFreeModule.__init__(self, ZZ, [k for k in self._names], category=cat)
-        if inject_variables:
-            self.inject_variables()
+        CombinatorialFreeModule.__init__(self, ZZ, [k for k in self._names],
+                                         prefix=prefix, bracket=False, category=cat)
 
     def _repr_(self):
         """
@@ -166,24 +213,6 @@ class FusionDouble(CombinatorialFreeModule):
         """
         return "The Fusion Ring of the Drinfeld Double of %s"%self._G
 
-    def _element_constructor(self, k):
-        """
-        Construct a monomial (basis element) from a key.
-
-        INPUT:
-
-        -  ``key`` -- a key for the dictionary `self._names`
-
-        EXAMPLES::
-
-            sage: F=FusionDouble(SymmetricGroup(3),prefix="n",inject_variables=True)
-            sage: F._names
-            {0: 'n0', 1: 'n1', 2: 'n2', 3: 'n3', 4: 'n4', 5: 'n5', 6: 'n6', 7: 'n7'}
-            sage: [F._element_constructor(x) for x in F._names]
-            [n0, n1, n2, n3, n4, n5, n6, n7]
-        """
-        return self.monomial(k)
-
     def inject_variables(self):
         """
         Create variables for the simple objects in the global name space.
@@ -192,57 +221,79 @@ class FusionDouble(CombinatorialFreeModule):
 
             sage: F = FusionDouble(DiCyclicGroup(3), prefix="d")
             sage: F.inject_variables()
-            sage: d4^2
+            sage: d0 + d1 + d5
             d0 + d1 + d5
         """
-        for i in range(self._rank):
-            inject_variable(self._names[i],self.monomial(i))
+        for i, name in self._names.items():
+            inject_variable(name, self.monomial(i))
+
+    @cached_method
+    def _char_cache(self, i, g):
+        """
+        Return ``self._chi[i](g)``, cached here for speed.
+
+        TESTS::
+
+            sage: D = FusionDouble(SymmetricGroup(4))
+            
+            sage: all(D._char_cache(b.support_of_term(), b.g()) == b.char()(b.g())
+            ....:     for b in D.basis())
+            True
+        """
+        return self._chi[i](g)
 
     @cached_method
     def s_ij(self, i, j, unitary=False, base_coercion=True):
         r"""
         Return the element of the S-matrix of this fusion ring
-        corresponding to the given elements. Without the unitary option
-        set true, this is the unnormalized S-matrix entry, denoted `\tilde{s}_{ij}`,
-        in [BaKi2001]_ Chapter 3. The normalized S-matrix entries are
-        denoted `s_{ij}`.
+        corresponding to the given elements.
+
+        Without the unitary option set true, this is the unnormalized S-matrix
+        entry, denoted `\tilde{s}_{ij}`, in [BaKi2001]_ Chapter 3. The
+        normalized S-matrix entries are denoted `s_{ij}`.
 
         INPUT:
 
         - ``i``, ``j``, -- a pair of basis elements
-        - ``unitary`` (optional): set true for the unitary normalized S-matrix.
+        - ``unitary`` -- (default: ``False``) set to ``True`` to obtain
+          the unitary S-matrix
 
         EXAMPLES::
 
-            sage: D = FusionDouble(SymmetricGroup(3),prefix="t",inject_variables=True)
-            sage: [D.s_ij(t2,x) for x in D.basis()]
+            sage: D = FusionDouble(SymmetricGroup(3), prefix="t", inject_variables=True)
+            sage: [D.s_ij(t2, x) for x in D.basis()]
             [2, 2, 4, 0, 0, -2, -2, -2]
-            sage: [D.s_ij(t2,x,unitary=True) for x in D.basis()]
+            sage: [D.s_ij(t2, x, unitary=True) for x in D.basis()]
             [1/3, 1/3, 2/3, 0, 0, -1/3, -1/3, -1/3]
         """
-        sum = 0
+        sum_val = ZZ.zero()
         G = self._G
-        [i, j] = [x.support_of_term() for x in [i,j]]
-        [a, chi_1] = [self._elt[i], self._chi[i]]
-        [b, chi_2] = [self._elt[j], self._chi[j]]
+        [i] = list(i._monomial_coefficients)
+        [j] = list(j._monomial_coefficients)
+        a = self._elt[i]
+        b = self._elt[j]
         for g in G:
-            if a*g*b*g.inverse() == g*b*g.inverse()*a:
-                sum += chi_1(g*b*g.inverse()) * chi_2(g.inverse()*a*g)
+            gi = g.inverse()
+            conj = g * b * gi
+            if a * conj == conj * a:
+                sum_val += self._char_cache(i, conj) * self._char_cache(j, gi * a * g)
         if unitary:
             coef = 1 / (G.centralizer(a).order() * G.centralizer(b).order())
         else:
             coef = G.order() / (G.centralizer(a).order() * G.centralizer(b).order())
-        ret = coef * sum
+        ret = coef * sum_val
         if (not base_coercion) or (self._basecoer is None):
             return ret
         return self._basecoer(ret)
 
     def s_ijconj(self, i, j, unitary=False, base_coercion=True):
-        """
+        r"""
         Return the conjugate of the element of the S-matrix given by
         ``self.s_ij(elt_i, elt_j, base_coercion=base_coercion)``.
 
-        See :meth:`s_ij`.
+        .. SEEALSO::
+
+            :meth:`s_ij`
 
         EXAMPLES::
 
@@ -295,14 +346,16 @@ class FusionDouble(CombinatorialFreeModule):
 
     @cached_method
     def N_ijk(self, i, j, k):
-        """
-        The symmetric invariant of three simple objects,
-        this returns the dimension of
+        r"""
+        The symmetric invariant of three simple objects.
+
+        This is the dimension of
 
         .. MATH::
-           Hom(i \\otimes j\\otimes k, s_0)
 
-        where `s_0` is the unit element (assuming prefix='s').
+           Hom(i \otimes j \otimes k, s_0),
+
+        where `s_0` is the unit element (assuming ``prefix='s'``).
         Method of computation is through the Verlinde formula,
         deducing the values from the known values of the S-matrix.
 
@@ -311,65 +364,93 @@ class FusionDouble(CombinatorialFreeModule):
             sage: A = FusionDouble(AlternatingGroup(4),prefix="a",inject_variables=True)
             sage: [A.N_ijk(a10,a11,x) for x in A.basis()]
             [0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]
+
+        TESTS::
+
+            sage: F = FusionDouble(SymmetricGroup(4))
+            sage: from itertools import product
+            sage: B = list(F.basis())
+            sage: all(F.N_ijk(i,j,k).parent() is ZZ
+            ....:     for i, j, k in product(B[::6], repeat=3))
+            True
         """
         sz = self.one()
-        return ZZ(sum(self.s_ij(i, r, unitary=True) * self.s_ij(j, r, unitary=True) * self.s_ij(k, r, unitary=True)/self.s_ij(sz, r, unitary=True) for r in self.basis()))
+        return ZZ(sum(self.s_ij(i, r, unitary=True) * self.s_ij(j, r, unitary=True)
+                      * self.s_ij(k, r, unitary=True) / self.s_ij(sz, r, unitary=True)
+                      for r in self.basis()))
 
     @cached_method
-    def Nk_ij(self, i, j, k):
+    def Nk_ij(self, i, j, k, use_characters=False):
         r"""
-        Returns the fusion coefficient `N^k_{ij}`, computed using the Verlinde formula:
+        Return the fusion coefficient `N^k_{ij}`.
+
+        INPUT:
+
+        - ``i``, ``j``, ``k`` -- basis elements
+        - ``use_characters`` -- (default: ``False``) see the algorithm
+          description below
+
+        ALGORITHM:
+
+        If ``use_characters=False``, then this is computed using
+        the Verlinde formula:
 
         .. MATH::
-            N^k_{ij} = \sum_l \frac{s(i, \ell)\, s(j, \ell)\, \overline{s(k, \ell)}}{s(I, \ell)},
+
+            N^k_{ij} = \sum_l \frac{s(i, \ell)\, s(j, \ell)\,
+            \overline{s(k, \ell)}}{s(I, \ell)}.
+
+        Otherwise we use a character theoretic method to compute the fusion
+        coefficient `N_{ij}^k` as follows. Each simple object, for example
+        `i` corresponds to a conjugacy class `\mathcal{C}_i` of the underlying
+        group `G`, and an irreducible character `\chi_i` of the centralizer
+        `C(g_i)` of a fixed representative `g_i` of `\mathcal{C}_i`. In addition
+        to the fixed representative `g_k` of the class `\mathcal{C}_i`
+        and `\mathcal{C}_j`, the formula will make use of variable elements
+        `h_i` and `h_j` that are subject to the condition `h_i h_j = g_k`.
+
+        .. MATH::
+
+            \frac{|\mathcal{C}_k|}{|G|}
+            \sum_{\substack{h_i\in\mathcal{C}_i \\ h_j\in\mathcal{C}_j \\ h_ih_j=g_k}}
+            \lvert C(h_i)\cap C(h_j) \rvert \,
+            \langle \chi_i^{(h_i)} \chi_j^{(h_j)}, \chi_k \rangle_{C(h_i)\cap C(h_j)},
+
+        where `\chi_i^{(h_i)}` is the character `\chi_i` of `C(g_i)`
+        conjugated to a character of `C(h_i)`, when `h_i` is a conjugate
+        of the fixed representative `g_i`. More exactly, there exists `r_i`
+        such that `r_i g_i r_i^{-1} = h_i`, and then `\chi_i^{(h_i)}(x) =
+        \chi_i(r_i^{-1}xr_i)`, and this definition does not depend on the
+        choice of `r_i`.
+
+        This formula is due to Christopher Goff [Goff1999]_ when the
+        centralizers are normal, and to Wenqi Li in the general case.
+
+        .. NOTE::
+
+            This should be functionally equivalent, and testing shows
+            that it is, but it is slower.
 
         EXAMPLES::
 
             sage: A = FusionDouble(AlternatingGroup(4),prefix="aa",inject_variables=True)
             sage: [A.Nk_ij(aa8,aa10,x) for x in A.basis()]
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 1]
-        """
-        return self.N_ijk(i, j, self.dual(k))
-
-    def char_Nk_ij(self, i, j, k):
-        r"""
-        Use the character theoretic method to compute the fusion coefficient `N_{ij}^k`.
-        This should be functionally equivalent to :meth:`Nk_ij`, and testing shows
-        that it is, but it is slower.
-
-        Each simple object, for example `i` corresponds to a conjugacy class `\mathcal{C}_i`
-        of the underlying group `G`, and an irreducible character `\chi_i` of the
-        centralizer `C(g_i)` of a fixed representative `g_i` of `\mathcal{C}_i`. In addition
-        to the fixed representative `g_k` of the class `\mathcal{C}_i`
-        and `\mathcal{C}_j`, the formula will make use of variable elements `h_i` and
-        `h_j` that are subject to the condition `h_ih_j=g_k`.
-
-        .. MATH::
-
-            \frac{|\mathcal{C}_k|}{|G|}\sum_{\substack{h_i\in\mathcal{C}_i\\ h_j\in\mathcal{C}_j\\ h_ih_j=g_k}}|C(h_i)\cap C(h_j)|\,
-            \langle\chi_i^{(h_i)}\chi_j^{(h_j)},\chi_k\rangle_{C(h_i)\cap C(h_j)},
-
-        where `\chi_i^{(h_i)}` is the character `\chi_i` of `C(g_i)` conjugated to a
-        character of `C(h_i)`, when `h_i` is a conjugate of the fixed representative `g_i`.
-        More exactly, there exists `r_i` such that `r_i g_i r_i^{-1}=h_i`, and then
-        `\chi_i^{(h_i)}(x)=\chi_i(r_i^{-1}xr_i)`, and this definition does not
-        depend on the choice of `r_i`.
-
-        This formula is due to Christopher Goff [Goff1999]_ when the centralizers are normal,
-        and to Wenqi Li in the general case.
-
-        EXAMPLES::
 
             sage: B = FusionDouble(CyclicPermutationGroup(2))
-            sage: all(B.char_Nk_ij(x,y,z)==B.Nk_ij(x,y,z) for x in B.basis() for y in B.basis() for z in B.basis())
+            sage: all(B.Nk_ij(x,y,z,use_characters=True) == B.Nk_ij(x,y,z)
+            ....:     for x in B.basis() for y in B.basis() for z in B.basis())
             True
         """
+        if not use_characters:
+            return self.N_ijk(i, j, self.dual(k))
+
         G = self._G
         I = G.conjugacy_class(i.g())
         J = G.conjugacy_class(j.g())
-        IJ = Set(I_elem * J_elem for I_elem in I for J_elem in J)
+        IJ = set(I_elem * J_elem for I_elem in I for J_elem in J)
         if k.g() not in IJ:
-            return 0
+            return ZZ.zero()
 
         K = G.conjugacy_class(k.g())
         CI = G.centralizer(i.g())
@@ -378,19 +459,25 @@ class FusionDouble(CombinatorialFreeModule):
 
         c = K.cardinality() / G.order()
         summands = [(I_elem, J_elem) for I_elem in I for J_elem in J if I_elem * J_elem == k.g()]
-        res = 0
+        res = ZZ.zero()
+        ichar = i.char()
+        jchar = j.char()
+        kchar = k.char()
         for p in summands:
             I_elem, J_elem = p
             for g in G:
-                if g.inverse() * i.g() * g == I_elem:
+                ginv = g.inverse()
+                if ginv * i.g() * g == I_elem:
                     i_twist = g
-                if g.inverse() * j.g() * g == J_elem:
+                if ginv * j.g() * g == J_elem:
                     j_twist = g
             A = Set(i_twist.inverse() * zi * i_twist for zi in CI)
             B = Set(j_twist.inverse() * zj * j_twist for zj in CJ)
             inner_summands = A.intersection(B).intersection(Set(CK))
-            for x in inner_summands:
-                res += i.char()(i_twist * x * i_twist.inverse()) * j.char()(j_twist * x * j_twist.inverse()) * k.char()(x).conjugate()
+            i_twist_inv = i_twist.inverse()
+            j_twist_inv = j_twist.inverse()
+            res += sum(ichar(i_twist * x * i_twist_inv) * jchar(j_twist * x * j_twist_inv) * kchar(x).conjugate()
+                       for x in inner_summands)
         return c * res
 
     @cached_method
@@ -481,15 +568,17 @@ class FusionDouble(CombinatorialFreeModule):
         """
         if self.Nk_ij(i, j, k) == 0:
             return self.field().zero() if (not base_coercion) or (self._basecoer is None) else self.fvars_field().zero()
+
         if i != j:
             ret = self.root_of_unity((k.twist() - i.twist() - j.twist()) / 2)
         else:
             i0 = self.one()
             B = self.basis()
             ret = sum(y.ribbon()**2 / (i.ribbon() * x.ribbon()**2)
-                   * self.s_ij(i0, y) * self.s_ij(i, z) * self.s_ijconj(x, z)
-                   * self.s_ijconj(k, x) * self.s_ijconj(y, z) / self.s_ij(i0, z)
-                   for x in B for y in B for z in B) / (self.total_q_order()**4)
+                      * self.s_ij(i0, y) * self.s_ij(i, z) * self.s_ijconj(x, z)
+                      * self.s_ijconj(k, x) * self.s_ijconj(y, z) / self.s_ij(i0, z)
+                      for x in B for y in B for z in B) / (self.total_q_order()**4)
+
         if (not base_coercion) or (self._basecoer is None):
             return ret
         return self._basecoer(ret)
@@ -509,11 +598,10 @@ class FusionDouble(CombinatorialFreeModule):
             sage: sum(x.q_dimension()^2 for x in H.basis())
             576
         """
-        ret = self._G.order()**2
+        ret = self._G.order() ** 2
         if (not base_coercion) or (self._basecoer is None):
             return ret
         return self._basecoer(ret)
-
 
     def total_q_order(self, base_coercion=True):
         r"""
@@ -521,7 +609,10 @@ class FusionDouble(CombinatorialFreeModule):
         <global_q_dimension>` as an element of :meth:`self.field() <field>`.
 
         For the Drinfeld double of a finite group `G`, this equals the
-        cardinality of `G`.
+        cardinality of `G`. This is also equal to `\sum d_i^2 \theta_i^{\pm 1}`,
+        where `i` runs through the simple objects, `d_i` is the quantum
+        dimension, and `\theta_i` is the twist. This sum with `\theta_i` is
+        denoted `p_-` in [BaKi2001]_ Chapter 3.
 
         EXAMPLES::
 
@@ -533,45 +624,11 @@ class FusionDouble(CombinatorialFreeModule):
             return ret
         return self._basecoer(ret)
 
-    def D_plus(self, base_coercion=True):
-        r"""
-        Return `\sum d_i^2\theta_i` where `i` runs through the simple objects,
-        `d_i` is the quantum dimension and `\theta_i` is the twist.
-
-        This is denoted `p_+` in [BaKi2001]_ Chapter 3. For the Drinfeld
-        double, it equals the order of the group.
-
-        EXAMPLES::
-
-            sage: FusionDouble(DihedralGroup(8)).D_plus()
-            16
-        """
-        ret = self._G.order()
-        if (not base_coercion) or (self._basecoer is None):
-            return ret
-        return self._basecoer(ret)
-
-    def D_minus(self, base_coercion=True):
-        r"""
-        Return `\sum d_i^2\theta_i^{-1}` where `i` runs through the simple
-        objects, `d_i` is the quantum dimension and `\theta_i` is the twist.
-
-        This is denoted `p_-` in [BaKi2001]_ Chapter 3. For the Drinfeld
-        double, it equals the order of the group.
-
-        EXAMPLES::
-
-            sage: FusionDouble(DihedralGroup(9)).D_minus()
-            18
-        """
-        ret = self._G.order()
-        if (not base_coercion) or (self._basecoer is None):
-            return ret
-        return self._basecoer(ret)
+    D_minus = D_plus = total_q_order
 
     def is_multiplicity_free(self, verbose=False):
         """
-        Returns True if all fusion coefficients are at most 1.
+        Return ``True`` if all fusion coefficients are at most 1.
 
         EXAMPLES::
 
@@ -579,34 +636,45 @@ class FusionDouble(CombinatorialFreeModule):
             True
             sage: FusionDouble(SymmetricGroup(4)).is_multiplicity_free()
             False
+
+            sage: FusionDouble(SymmetricGroup(3)).is_multiplicity_free(True)
+            Checking multiplicity freeness
+            True
+            sage: FusionDouble(SymmetricGroup(4)).is_multiplicity_free(True)
+            Checking multiplicity freeness
+            N(s2,s13,s13) = 2
+            False
         """
         if verbose:
-            print("Checking multiplicity free-ness")
-        for i in self.basis():
-            for j in self.basis():
-                for k in self.basis():
-                    if self.N_ijk(i,j,k) > 1:
-                        if verbose:
-                            print("N(%s,%s,%s)=%s"%(i,j,k,self.N_ijk(i,j,k)))
-                        return False
-        return True
+            print("Checking multiplicity freeness")
+            from itertools import product
+            for (i, j, k) in product(self.basis(), repeat=3):
+                if self.N_ijk(i, j, k) > 1:
+                    print("N(%s,%s,%s) = %s" % (i, j, k, self.N_ijk(i, j, k)))
+                    return False
+            return True
 
-    def one(self):
-        """
+        return all(self.N_ijk(i,j,k) <= 1 for i in self.basis()
+                   for j in self.basis() for k in self.basis())
+
+    @cached_method
+    def one_basis(self):
+        r"""
         The unit element of the ring, which is the first basis element.
 
         EXAMPLES::
 
-            sage: FusionDouble(CyclicPermutationGroup(2),prefix="h").one()
+            sage: FusionDouble(CyclicPermutationGroup(2), prefix="h").one()
             h0
         """
-        return self.basis()[0]
+        return ZZ.zero()
 
     @cached_method
-    def dual(self,i):
+    def dual(self, i):
         r"""
-        Return the dual object ``i^\ast`` to ``i``. The dual is also
-        available as an element method of ``i``.
+        Return the dual object ``i^\ast`` to ``i``.
+
+        The dual is also available as an element method of ``i``.
 
         EXAMPLES::
 
@@ -626,7 +694,7 @@ class FusionDouble(CombinatorialFreeModule):
         """
         sz = self.one()
         for j in self.basis():
-            if self.N_ijk(i,j,sz) > 0:
+            if self.N_ijk(i, j, sz) > 0:
                 return j
 
     def product_on_basis(self, a, b):
@@ -647,22 +715,13 @@ class FusionDouble(CombinatorialFreeModule):
             sage: Q.product_on_basis(3,4)
             q1 + q2 + q5 + q6 + q7
         """
-        d = {k.support_of_term() : self.N_ijk(self.monomial(a),self.monomial(b),self.dual(k)) for k in self.basis()}
-        return self._from_dict(d)
-
-    def _repr_term(self, t):
-        """
-        EXAMPLES::
-
-            sage: F = FusionDouble(CyclicPermutationGroup(2))
-            sage: [F._repr_term(t) for t in F._names]
-            ['s0', 's1', 's2', 's3']
-        """
-        return self._names[t]
+        d = {k.support_of_term(): val for k in self.basis()
+             if (val := self.N_ijk(self.monomial(a),self.monomial(b),self.dual(k)))}
+        return self._from_dict(d, remove_zeros=False)
 
     def group(self):
         """
-        Returns the underlying group.
+        Return the underlying group.
 
         EXAMPLES::
 
@@ -671,24 +730,10 @@ class FusionDouble(CombinatorialFreeModule):
         """
         return self._G
 
-    def IdGroup(self):
-        """
-        Returns the GAP Small Group identifier. This is a pair ``[n,k]`` where ``n`` is
-        the order of the group, and ``k`` is an integer characterizing the
-        isomorphism class of the group, available for very many groups.
-
-        EXAMPLES::
-
-            sage: FusionDouble(DiCyclicGroup(4)).IdGroup()
-            [ 16, 9 ]
-
-        """
-        return self._G._libgap_().IdGroup()
-
     def get_fmatrix(self, *args, **kwargs):
-        """
-        Construct an :class:`FMatrix` factory to solve the pentagon and hexagon relations
-        and organize the resulting F-symbols.
+        r"""
+        Construct an :class:`FMatrix` factory to solve the pentagon and
+        hexagon relations and organize the resulting F-symbols.
 
         EXAMPLES::
 
@@ -701,21 +746,6 @@ class FusionDouble(CombinatorialFreeModule):
             self.fmats = FMatrix(self, *args, **kwargs)
         return self.fmats
 
-    def get_order(self):
-        r"""
-        Return the keys of the basis vectors in a fixed order, needed
-        for the F-matrix code.
-
-        EXAMPLES::
-
-            sage: FusionDouble(SymmetricGroup(4)).get_order()
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-
-        """
-        if self._order is None:
-            self.set_order(self.basis().keys().list())
-        return self._order
-
     class Element(CombinatorialFreeModule.Element):
         def is_simple_object(self):
             r"""
@@ -723,11 +753,11 @@ class FusionDouble(CombinatorialFreeModule):
 
             EXAMPLES::
 
-                sage: H=FusionDouble(CyclicPermutationGroup(2),prefix="g",inject_variables=True)
-                sage: [x.is_simple_object() for x in [g0,g1,g0+g1]]
+                sage: H = FusionDouble(CyclicPermutationGroup(2), prefix="g", inject_variables=True)
+                sage: [x.is_simple_object() for x in [g0, g1, g0+g1]]
                 [True, True, False]
             """
-            return self in self.parent().basis()
+            return len(self._monomial_coefficients) == 1
 
         def g(self):
             r"""
@@ -741,27 +771,29 @@ class FusionDouble(CombinatorialFreeModule):
             EXAMPLES::
 
                 sage: G = QuaternionGroup()
-                sage: H = FusionDouble(G,prefix="e",inject_variables=True)
+                sage: H = FusionDouble(G, prefix="e", inject_variables=True)
                 sage: e10.g()
                 (1,3)(2,4)(5,7)(6,8)
                 sage: e10.char()
                 Character of Subgroup generated by [(1,2,3,4)(5,6,7,8), (1,5,3,7)(2,8,4,6)] of
-                (Quaternion group of order 8 as a permutation group)
+                 (Quaternion group of order 8 as a permutation group)
             """
             return self.parent()._elt[self.support_of_term()]
 
         def char(self):
             r"""
+            Return the character `\chi` corresponding to ``self``.
+
             The data determining a simple object consists of a conjugacy
             class representative `g` and an irreducible character `\chi` of
             the centralizer of `g`.
 
-            Returns the character `chi`. See also :meth:`g`.
+            .. SEEALSO:: :meth:`g`
 
             EXAMPLES::
 
                 sage: G = DihedralGroup(5)
-                sage: H = FusionDouble(G,prefix="f",inject_variables=True)
+                sage: H = FusionDouble(G, prefix="f", inject_variables=True)
                 sage: f10.g()
                 (1,2,3,4,5)
                 sage: f10.char()
@@ -779,16 +811,19 @@ class FusionDouble(CombinatorialFreeModule):
                 sage: [i.ribbon() for i in H.basis()]
                 [1, 1, 1, 1, zeta3, -zeta3 - 1, 1, -zeta3 - 1, zeta3]
             """
-            ret = self.char()(self.g()) / self.char()(self.parent()._G.one())
-            if (not base_coercion) or (self.parent()._basecoer is None):
+            i = self.support_of_term()
+            P = self.parent()
+            ret = P._char_cache(i, self.g()) / P._char_cache(i, P._G.one())
+            if (not base_coercion) or (P._basecoer is None):
                 return ret
             return self.parent()._basecoer(ret)
 
         def twist(self, reduced=True):
             r"""
             Return a rational number `h` such that `\theta = e^{i \pi h}`
-            is the twist of ``self``. The quantity `e^{i \pi h}` is
-            also available using :meth:`ribbon`.
+            is the twist of ``self``.
+
+            The quantity `e^{i \pi h}` is also available using :meth:`ribbon`.
 
             This method is only available for simple objects.
 
@@ -799,34 +834,56 @@ class FusionDouble(CombinatorialFreeModule):
                 [0, 0, 0, 0, 2/3, 4/3, 0, 4/3, 2/3]
                 sage: [x.ribbon() for x in Q.basis()]
                 [1, 1, 1, 1, zeta3, -zeta3 - 1, 1, -zeta3 - 1, zeta3]
+
+            TESTS::
+
+                sage: H = FusionDouble(AlternatingGroup(4))
+                sage: sum(H.basis()).twist()
+                Traceback (most recent call last):
+                ...
+                ValueError: quantum twist is only available for simple objects
             """
             if not self.is_simple_object():
-                raise ValueError("quantum twist is only available for simple objects of a FusionRing")
-            zeta = self.parent().field().gen()
+                raise ValueError("quantum twist is only available for simple objects")
+            P = self.parent()
+            zeta = P.field().gen()
             rib = self.ribbon()
-            for k in range(4*self.parent()._cyclotomic_order):
-                if zeta**k == rib:
-                    return k/(2*self.parent()._cyclotomic_order)
+            norm = 2 * P._cyclotomic_order
+            for k in range(4*P._cyclotomic_order):
+                if zeta ** k == rib:
+                    return k / norm
 
         def dual(self):
             """
-            Return the dual of self.
+            Return the dual of ``self``.
+
+            This method is only available for simple objects.
 
             EXAMPLES::
 
                 sage: G = CyclicPermutationGroup(4)
                 sage: H = FusionDouble(G, prefix="j")
-                sage: [x for x in H.basis() if x==x.dual()]
+                sage: [x for x in H.basis() if x == x.dual()]
                 [j0, j1, j8, j9]
+
+            TESTS::
+
+                sage: H = FusionDouble(AlternatingGroup(4))
+                sage: sum(H.basis()).dual()
+                Traceback (most recent call last):
+                ...
+                ValueError: dual is only available for simple objects
             """
             if not self.is_simple_object():
-                raise ValueError("dual is only available for simple objects of a FusionRing")
+                raise ValueError("dual is only available for simple objects")
             return self.parent().dual(self)
 
         @cached_method
         def q_dimension(self, base_coercion=True):
             """
-            Return the q-dimension of self.
+            Return the q-dimension of ``self``.
+
+            This method is only available for simple objects.
 
             EXAMPLES::
 
@@ -836,7 +893,15 @@ class FusionDouble(CombinatorialFreeModule):
                 [1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4]
                 sage: sum(x.q_dimension()^2 for x in H.basis()) == G.order()^2
                 True
+
+            TESTS::
+
+                sage: H = FusionDouble(AlternatingGroup(4))
+                sage: sum(H.basis()).q_dimension()
+                Traceback (most recent call last):
+                ...
+                ValueError: quantum dimension is only available for simple objects
             """
             if not self.is_simple_object():
-                raise ValueError("quantum dimension is only available for simple objects of a FusionRing")
+                raise ValueError("quantum dimension is only available for simple objects")
             return self.parent().s_ij(self,self.parent().one())

--- a/src/sage/algebras/fusion_rings/fusion_ring.py
+++ b/src/sage/algebras/fusion_rings/fusion_ring.py
@@ -8,7 +8,10 @@ Fusion Rings
 #                     Nicolas Thiery <nthiery at users.sf.net>
 #                2022 Guillermo Aboumrad <gh_willieab>
 #
-#  Distributed under the terms of the GNU General Public License (GPL)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
@@ -813,9 +816,11 @@ class FusionRing(WeylCharacterRing):
     def s_ij(self, elt_i, elt_j, base_coercion=True):
         r"""
         Return the element of the S-matrix of this fusion ring corresponding to
-        the given elements. This is the unnormalized S-matrix, denoted
-        `\tilde{s}_{ij}` in [BaKi2001]_ . To obtain the normalized S-matrix,
-        divide by ``self.global_q_dimension()`` or use ``self.S_matrix()`` with
+        the given elements.
+
+        This is the unnormalized S-matrix, denoted `\tilde{s}_{ij}`
+        in [BaKi2001]_ . To obtain the normalized S-matrix, divide by
+        :meth:`global_q_dimension()` or use :meth:`S_matrix()` with
         the option ``unitary=True``.
 
         This is computed using the formula


### PR DESCRIPTION
I made a number of reviewer changes:

- Massive speedup for multiplication: the one test for $GL(2,3)$ went from ~28s to ~5s on my computer. Achieved by caching the bottleneck: computing the character values.
- Return the same object independent of `inject_variables`.
- Removed unused methods and reduced code duplication through aliases.
- Other misc speedups by avoiding repeating computations.
- Misc doc improvements and fixes.